### PR TITLE
file changes for lexical extents of a compiler

### DIFF
--- a/clang-tools-extra/CMakeLists.txt
+++ b/clang-tools-extra/CMakeLists.txt
@@ -17,7 +17,7 @@ add_subdirectory(clang-apply-replacements)
 add_subdirectory(clang-reorder-fields)
 add_subdirectory(modularize)
 add_subdirectory(clang-tidy)
-
+add_subdirectory(find-class-decls)
 add_subdirectory(clang-change-namespace)
 add_subdirectory(clang-doc)
 add_subdirectory(clang-include-fixer)

--- a/clang-tools-extra/find-class-decls/CMakeLists.txt
+++ b/clang-tools-extra/find-class-decls/CMakeLists.txt
@@ -1,0 +1,14 @@
+set(LLVM_LINK_COMPONENTS
+  Support
+  )
+
+add_clang_executable(find-class-decls FindClassDecls.cpp)
+
+target_link_libraries(find-class-decls
+  PRIVATE
+  clangAST
+  clangBasic
+  clangFrontend
+  clangSerialization
+  clangTooling
+  )

--- a/clang-tools-extra/find-class-decls/FindClassDecls.cpp
+++ b/clang-tools-extra/find-class-decls/FindClassDecls.cpp
@@ -1,0 +1,54 @@
+#include "clang/AST/ASTConsumer.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Frontend/FrontendAction.h"
+#include "clang/Tooling/Tooling.h"
+
+using namespace clang;
+
+class FindNamedClassVisitor
+  : public RecursiveASTVisitor<FindNamedClassVisitor> {
+public:
+  explicit FindNamedClassVisitor(ASTContext *Context)
+    : Context(Context) {}
+
+  bool VisitCXXRecordDecl(CXXRecordDecl *Declaration) {
+    if (Declaration->getQualifiedNameAsString() == "n::m::C") {
+      FullSourceLoc FullLocation = Context->getFullLoc(Declaration->getBeginLoc());
+      if (FullLocation.isValid())
+        llvm::outs() << "Found declaration at "
+                     << FullLocation.getSpellingLineNumber() << ":"
+                     << FullLocation.getSpellingColumnNumber() << "\n";
+    }
+    return true;
+  }
+
+private:
+  ASTContext *Context;
+};
+
+class FindNamedClassConsumer : public clang::ASTConsumer {
+public:
+  explicit FindNamedClassConsumer(ASTContext *Context)
+    : Visitor(Context) {}
+
+  virtual void HandleTranslationUnit(clang::ASTContext &Context) {
+    Visitor.TraverseDecl(Context.getTranslationUnitDecl());
+  }
+private:
+  FindNamedClassVisitor Visitor;
+};
+
+class FindNamedClassAction : public clang::ASTFrontendAction {
+public:
+  virtual std::unique_ptr<clang::ASTConsumer> CreateASTConsumer(
+    clang::CompilerInstance &Compiler, llvm::StringRef InFile) {
+    return std::make_unique<FindNamedClassConsumer>(&Compiler.getASTContext());
+  }
+};
+
+int main(int argc, char **argv) {
+  if (argc > 1) {
+    clang::tooling::runToolOnCode(std::make_unique<FindNamedClassAction>(), argv[1]);
+  }
+}

--- a/clang-tools-extra/find-class-decls/findClassDecls.py
+++ b/clang-tools-extra/find-class-decls/findClassDecls.py
@@ -1,0 +1,50 @@
+import sys
+import re
+
+def find_all_class_and_struct_extents(cpp_code):
+    class_pattern = r'\b(class|struct|union)\s+(\w+)\b'
+    class_matches = re.finditer(class_pattern, cpp_code)
+
+    class_extents = []
+
+    for match in class_matches:
+        class_kind = match.group(1)
+        class_name = match.group(2)
+        start_line = cpp_code.count('\n', 0, match.start()) + 1
+
+        # Find the end of the class/struct/union definition by searching for the next '}'
+        end_pos = match.end()
+        brace_count = 1
+        while brace_count > 0 and end_pos < len(cpp_code):
+            if cpp_code[end_pos] == '{':
+                brace_count += 1
+            elif cpp_code[end_pos] == '}':
+                brace_count -= 1
+            end_pos += 1
+
+        end_line = cpp_code.count('\n', 0, end_pos) + 1
+        class_extents.append((class_kind, class_name, start_line, end_line))
+
+    return class_extents
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python script.py input.cpp")
+        sys.exit(1)
+
+    input_file = sys.argv[1]
+
+    try:
+        with open(input_file, 'r') as file:
+            cpp_code = file.read()
+    except FileNotFoundError:
+        print(f"Error: File '{input_file}' not found.")
+        sys.exit(1)
+
+    class_extents = find_all_class_and_struct_extents(cpp_code)
+
+    if not class_extents:
+        print("No class, struct, or union definitions found in the code.")
+    else:
+        for class_kind, class_name, start_line, end_line in class_extents:
+            print(f"The {class_kind} '{class_name}' : {start_line} - {end_line}.")

--- a/clang-tools-extra/find-class-decls/sampleInputFile.txt
+++ b/clang-tools-extra/find-class-decls/sampleInputFile.txt
@@ -1,0 +1,35 @@
+
+  class GlobalDeclRefChecker final : public ConstStmtVisitor<GlobalDeclRefChecker> {
+    Decl *TargetDecl;
+    SmallVector<VarDecl *> DeclVector;
+
+  public:
+    void VisitDeclRefExpr(const DeclRefExpr *Node) {
+      if (auto *VD = const_cast<VarDecl *>(dyn_cast<VarDecl>(Node->getDecl()))) {
+        VD->addAttr(TargetDecl->getAttr<OMPDeclareTargetDeclAttr>());
+        DeclVector.push_back(VD);
+      }
+    }
+
+    void declTargetInitializer(Decl *TD) {
+      TargetDecl = TD;
+      DeclVector.push_back(dyn_cast<VarDecl>(TD));
+
+      while (!DeclVector.empty()) {
+        VarDecl *TargetVarDecl = DeclVector.pop_back_val();
+        if (TargetVarDecl->hasAttr<OMPDeclareTargetDeclAttr>() &&
+            TargetVarDecl->hasInit() &&
+            TargetVarDecl->hasGlobalStorage()) {
+          Expr *Ex = TargetVarDecl->getInit();
+          assert(Ex...); // Must be true since hasInit returned true
+          if (auto *DeclRef = dyn_cast_or_null<DeclRefExpr>(Ex)) {
+            VisitDeclRefExpr(DeclRef);
+          } else {
+            for (auto it = Ex->child_begin(); it != Ex->child_end(); ++it) {
+              Visit(*it);
+            }
+          }
+        }
+      }
+    }
+  };


### PR DESCRIPTION
Issue #33 #34 
Created a sub-directory for find-class-decls
Created a clang plugin using AST in FindClassDecls.cpp
Added a CMakeLists.txt 
Errors in include statements and CMakeLists, which according to documentation should be correct.
And add-clang-executable function in CMakeList is not being recognized as it should have done according to the tutorial in clang plugin documentation.
As a sample output program, we have included a python script to get the desired output for the same.